### PR TITLE
109827790 reimann logback appender tcp support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 /target
 /classes
 /checkouts

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,9 @@
+# 0.1.6 -- UNRELEASED
+
+The RiemannAdapter can now be configured to use TCP, with the new `tcp` property.
+The default (for now) is to continue using UDP.
+
+Incompatible changes:
+
+Some properties of RiemannAdapter have changed from string to an appropriate type
+(int or boolean); 

--- a/dev-resources/user.clj
+++ b/dev-resources/user.clj
@@ -8,14 +8,12 @@
   ([] (make-appender {}))
   ([options]
      (doto (RiemannAppender.)
-       (.setRiemannHostname (or (:riemann-host options)
-                                "localhost"))
-       (.setRiemannPort (or` (:riemann-port options)
-                            "5555"))
+       (.setRiemannHostname (:riemann-host options RiemannAppender/DEFAULT_HOST))
+       (.setRiemannPort (:riemann-port options RiemannAppender/DEFAULT_PORT))
+       (.setTcp (:tcp options false))
        (.setHostname "repl-test-appender")
-       (.setServiceName (or (:service options)
-                            "repl-test-service"))
-       (.setDebug "true")
+       (.setServiceName (:service options "repl-test-service"))
+       (.setDebug true)
        (.start))))
 
 (defn make-marker

--- a/dev-resources/user.clj
+++ b/dev-resources/user.clj
@@ -1,10 +1,16 @@
+(ns user
+  (:import (com.walmartlabs.logback RiemannAppender)
+           (org.slf4j MarkerFactory LoggerFactory)
+           (ch.qos.logback.classic.spi LoggingEvent)
+           (ch.qos.logback.classic Level)))
+
 (defn make-appender
   ([] (make-appender {}))
   ([options]
-     (doto (com.walmartlabs.logback.RiemannAppender.)
+     (doto (RiemannAppender.)
        (.setRiemannHostname (or (:riemann-host options)
                                 "localhost"))
-       (.setRiemannPort (or (:riemann-port options)
+       (.setRiemannPort (or` (:riemann-port options)
                             "5555"))
        (.setHostname "repl-test-appender")
        (.setServiceName (or (:service options)
@@ -14,16 +20,16 @@
 
 (defn make-marker
   []
-  (org.slf4j.MarkerFactory/getMarker "repl-marker"))
+  (MarkerFactory/getMarker "repl-marker"))
 
-(def logger (org.slf4j.LoggerFactory/getLogger "repl-logger"))
+(def logger (LoggerFactory/getLogger "repl-logger"))
 
 (defn make-event
   ([msg] (make-event msg {}))
   ([msg fields]
-   (make-event ch.qos.logback.classic.Level/ERROR msg fields))
+   (make-event Level/ERROR msg fields))
   ([level msg fields]
-   (doto (ch.qos.logback.classic.spi.LoggingEvent. "fully-qualified-class-name"
+   (doto (LoggingEvent. "fully-qualified-class-name"
                                                    logger
                                                    level
                                                    msg

--- a/dev-resources/user.clj
+++ b/dev-resources/user.clj
@@ -28,11 +28,11 @@
    (make-event Level/ERROR msg fields))
   ([level msg fields]
    (doto (LoggingEvent. "fully-qualified-class-name"
-                                                   logger
-                                                   level
-                                                   msg
-                                                   nil
-                                                   nil)
+                        logger
+                        level
+                        msg
+                        nil
+                        nil)
      (.setTimeStamp (System/currentTimeMillis))
      (.setMarker (make-marker))
      (.setMDCPropertyMap fields))))

--- a/java/com/walmartlabs/logback/RiemannAppender.java
+++ b/java/com/walmartlabs/logback/RiemannAppender.java
@@ -98,6 +98,7 @@ public class RiemannAppender<E> extends AppenderBase<E> {
     return result;
   }
 
+  // Invoked from the Clojure code, but is only used for testing.
   public void forceAppend(E event) {
     append(event);
   }

--- a/java/com/walmartlabs/logback/RiemannAppender.java
+++ b/java/com/walmartlabs/logback/RiemannAppender.java
@@ -12,9 +12,7 @@ import com.aphyr.riemann.client.SynchronousTransport;
 
 import java.io.IOException;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class RiemannAppender<E> extends AppenderBase<E> {

--- a/java/com/walmartlabs/logback/RiemannAppender.java
+++ b/java/com/walmartlabs/logback/RiemannAppender.java
@@ -61,11 +61,7 @@ public class RiemannAppender<E> extends AppenderBase<E> {
       printError("%s.stop()", this);
     }
     if (riemannClient != null) {
-      try {
-        riemannClient.disconnect();
-      } catch (IOException ex) {
-        // do nothing, it's ok
-      }
+      riemannClient.close();
     }
     super.stop();
   }

--- a/java/com/walmartlabs/logback/RiemannAppender.java
+++ b/java/com/walmartlabs/logback/RiemannAppender.java
@@ -78,7 +78,7 @@ public class RiemannAppender<E> extends AppenderBase<E> {
       "RiemannAppender{hashCode=%s;serviceName=%s;transport=%s;riemannHostname=%s;riemannPort=%d;hostname=%s}",
       hashCode(),
       serviceName,
-      tcp ? "tcp" : "upd",
+      tcp ? "tcp" : "udp",
       riemannHostname,
       riemannPort,
       hostname);

--- a/java/com/walmartlabs/logback/RiemannAppender.java
+++ b/java/com/walmartlabs/logback/RiemannAppender.java
@@ -61,7 +61,11 @@ public class RiemannAppender<E> extends AppenderBase<E> {
       printError("%s.stop()", this);
     }
     if (riemannClient != null) {
-      riemannClient.close();
+      try {
+        riemannClient.disconnect();
+      } catch (IOException ex) {
+        // do nothing, it's ok
+      }
     }
     super.stop();
   }

--- a/project.clj
+++ b/project.clj
@@ -13,11 +13,10 @@
                    :source-paths ["test/clojure"]
                    :java-source-paths ["test/java"]}
              :repl {:source-paths ["dev"]}}
-  :dependencies [
-    [org.clojure/clojure            "1.7.0"]
-    [com.aphyr/riemann-java-client  "0.2.11"]
-    [ch.qos.logback/logback-classic "1.0.13"]
-    [org.clojure/tools.logging      "0.2.6"]]
+  :dependencies [[org.clojure/clojure "1.7.0"]
+                 [com.aphyr/riemann-java-client "0.2.11"]
+                 [ch.qos.logback/logback-classic "1.1.3"]
+                 [org.clojure/tools.logging "0.3.1"]]
   :signing {:gpg-key "dante@walmartlabs.com"}
   :release-tasks [["vcs" "assert-committed"]
                   ["change" "version" "leiningen.release/bump-version" "release"]

--- a/project.clj
+++ b/project.clj
@@ -18,6 +18,7 @@
                  [ch.qos.logback/logback-classic "1.1.3"]
                  [org.clojure/tools.logging "0.3.1"]]
   :signing {:gpg-key "dante@walmartlabs.com"}
+  :aliases {"test" ["do", "jar," "test"]}
   :release-tasks [["vcs" "assert-committed"]
                   ["change" "version" "leiningen.release/bump-version" "release"]
                   ["vcs" "commit"]

--- a/project.clj
+++ b/project.clj
@@ -15,9 +15,9 @@
              :repl {:source-paths ["dev"]}}
   :dependencies [
     [org.clojure/clojure            "1.7.0"]
-    [com.aphyr/riemann-java-client  "0.2.11"]
-    [ch.qos.logback/logback-classic "1.0.13"]
-    [org.clojure/tools.logging      "0.2.6"]]
+    [com.aphyr/riemann-java-client  "0.4.0"]
+    [ch.qos.logback/logback-classic "1.1.3"]
+    [org.clojure/tools.logging      "0.3.1"]]
   :signing {:gpg-key "dante@walmartlabs.com"}
   :release-tasks [["vcs" "assert-committed"]
                   ["change" "version" "leiningen.release/bump-version" "release"]

--- a/project.clj
+++ b/project.clj
@@ -14,8 +14,8 @@
                    :java-source-paths ["test/java"]}
              :repl {:source-paths ["dev"]}}
   :dependencies [
-    [org.clojure/clojure            "1.5.1"]
-    [com.aphyr/riemann-java-client  "0.2.8"]
+    [org.clojure/clojure            "1.7.0"]
+    [com.aphyr/riemann-java-client  "0.2.11"]
     [ch.qos.logback/logback-classic "1.0.13"]
     [org.clojure/tools.logging      "0.2.6"]]
   :signing {:gpg-key "dante@walmartlabs.com"}

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.walmartlabs/logback-riemann-appender "0.1.5"
+(defproject com.walmartlabs/logback-riemann-appender "0.1.6"
   :description "Logback Appender that sends events to Riemann"
   :url "https://github.com/walmartlabs/logback-riemann-appender"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -15,9 +15,9 @@
              :repl {:source-paths ["dev"]}}
   :dependencies [
     [org.clojure/clojure            "1.7.0"]
-    [com.aphyr/riemann-java-client  "0.4.0"]
-    [ch.qos.logback/logback-classic "1.1.3"]
-    [org.clojure/tools.logging      "0.3.1"]]
+    [com.aphyr/riemann-java-client  "0.2.11"]
+    [ch.qos.logback/logback-classic "1.0.13"]
+    [org.clojure/tools.logging      "0.2.6"]]
   :signing {:gpg-key "dante@walmartlabs.com"}
   :release-tasks [["vcs" "assert-committed"]
                   ["change" "version" "leiningen.release/bump-version" "release"]


### PR DESCRIPTION
Add support for TCP based connections when using logback appender.

https://www.pivotaltracker.com/story/show/109827790

I also cleaned up a few things, like properties of RiemannAppender being strings rather than proper types (int, boolean).  Joran takes care of that.

I've advanced the version number to 0.1.6 and created a CHANGES.md as well (this is just habit from my OSS projects). After merging, we can set the date in CHANGES.md and push a release into the Maven repo.

Updated 3rd party dependencies, where possible, to latest.

@kgann @dbriones 
