### PR TITLE
Allow configuration via system property

### DIFF
--- a/java/com/walmartlabs/logback/RiemannAppender.java
+++ b/java/com/walmartlabs/logback/RiemannAppender.java
@@ -36,12 +36,7 @@ public class RiemannAppender<E> extends AppenderBase<E> {
   private RiemannClient riemannClient = null;
 
   private String determineRiemannHostname() {
-    String rhn = System.getProperty("riemann.hostname");
-    if (rhn == null) {
-      return DEFAULT_HOST;
-    } else {
-      return rhn;
-    }
+    return System.getProperty("riemann.hostname", DEFAULT_HOST);
   }
 
   private String determineHostname() {

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.walmartlabs/logback-riemann-appender "0.1.6"
+(defproject com.walmartlabs/logback-riemann-appender "0.1.6-SNAPSHOT"
   :description "Logback Appender that sends events to Riemann"
   :url "https://github.com/walmartlabs/logback-riemann-appender"
   :license {:name "Eclipse Public License"

--- a/test/java/com/walmartlabs/logback/RiemannAppenderTest.java
+++ b/test/java/com/walmartlabs/logback/RiemannAppenderTest.java
@@ -2,17 +2,16 @@ package com.walmartlabs.logback;
 
 
 import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.spi.*;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.LoggingEvent;
 import org.junit.Test;
-import org.slf4j.Marker;
-import org.slf4j.MarkerFactory;
 
-import java.util.HashMap;
+import java.net.InetAddress;
 import java.util.Map;
+import java.util.UUID;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.*;
 
 public class RiemannAppenderTest {
 
@@ -60,6 +59,47 @@ public class RiemannAppenderTest {
     assertTrue(appender.isMinimumLevel(errorEvent));
   }
 
+  @Test
+  public void hostnameShouldDefaultToAddressOfLocalMachine() throws Exception {
+    String hostname = InetAddress.getLocalHost().getHostName();
+    RiemannAppender<ILoggingEvent> appender = new RiemannAppender<ILoggingEvent>();
+    assertThat(appender.toString(), containsString("hostname=" + hostname));
+  }
+
+  @Test
+  public void hostnameShouldBeOverridableViaSystemProperty() throws Exception {
+    String hostname = UUID.randomUUID().toString();
+    System.setProperty("hostname", hostname);
+    RiemannAppender<ILoggingEvent> appender = new RiemannAppender<ILoggingEvent>();
+    assertThat(appender.toString(), containsString("hostname=" + hostname));
+  }
+
+  @Test
+  public void hostnamePropertyShouldOverrideDefaultAndSystemProperty() throws Exception {
+    String hostname = UUID.randomUUID().toString();
+    System.setProperty("hostname", hostname);
+    RiemannAppender<ILoggingEvent> appender = new RiemannAppender<ILoggingEvent>();
+    String hostnameProperty = UUID.randomUUID().toString();
+    appender.setHostname(hostnameProperty);
+    assertThat(appender.toString(), containsString("hostname=" + hostnameProperty));
+  }
+
+  @Test
+  public void riemannHostnameShouldDefaultToLocalhost() throws Exception {
+    RiemannAppender<ILoggingEvent> appender = new RiemannAppender<ILoggingEvent>();
+    assertThat(appender.toString(), containsString("riemannHostname=localhost"));
+  }
+
+  @Test
+  public void riemannHostnameShouldBeOverridableViaSystemProperty() throws Exception {
+    String riemannHostname = UUID.randomUUID().toString();
+    System.setProperty("riemann.hostname", riemannHostname);
+    RiemannAppender<ILoggingEvent> appender = new RiemannAppender<ILoggingEvent>();
+    String riemannHostnameProperty = UUID.randomUUID().toString();
+    appender.setRiemannHostname(riemannHostnameProperty);
+    assertThat(appender.toString(), containsString("riemannHostname=" + riemannHostnameProperty));
+  }
+
   private Map<String, String> getCustomAttributes(String attributeString) {
     return new RiemannAppender<ILoggingEvent>().parseCustomAttributes(attributeString);
   }
@@ -75,5 +115,4 @@ public class RiemannAppenderTest {
   private static class TestInfoEvent extends LoggingEvent {
     public Level getLevel() { return Level.INFO; }
   }
-
 }


### PR DESCRIPTION
This commit allows users to configure the `hostname` and
`riemannHostname` properties via Java system property. These
configurations can vary from node to node (and from datacenter to
datacenter), so it's useful to be able to exclude them from the Logback
configuration file in a Docker-based deployment environment -- the
Docker image won't contain configuration that applies to only a subset
of the target hosts.

The configs are passed as system properties, allowing users to configure
them via command-line flags. Users might could instead use environment
variables by providing a shim that converts environment vars to system
properties at application startup.

This commit also sets a more sensible default for the `hostname`
property; previously, it was a meaningless string; now it uses the
hostname obtained from `InetAddress.getLocalHost()`. The hostname can be
configured via any one of the three following methods, in decreasing
order of precedence:
- The `hostname` property on the appender itself (that is, using the
  normal Logback XML config)
- The `hostname` system property
- Default value (`InetAddress.getLocalHost()`)

The `riemannHostname` property follows a similar precedence rule:
- The `riemannHostname` property on the appender
- The `riemann.hostname` system property
- Default value "`localhost`"

Ping @hlship 
